### PR TITLE
Revert "bump actions/artifact from 3 to 4"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,7 +90,7 @@ jobs:
       id-token: write # IMPORTANT: mandatory for trusted publishing
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: python-package-distributions
           path: dist/
@@ -106,7 +106,7 @@ jobs:
       contents: write # IMPORTANT: mandatory for creating release
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: python-package-distributions
           path: dist/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           hatch build --target sdist
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: python-package-distributions
           path: dist/


### PR DESCRIPTION
<!-- Thanks for contributing 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

fix #12 by:

- [Revert "build(deps): bump actions/upload-artifact from 3 to 4"](https://github.com/WSH032/aria2-wheel/commit/92acbace96d0d49c76dbd1c0b8a1eed6ce991895)
- [Revert "build(deps): bump actions/download-artifact from 3 to 4"](https://github.com/WSH032/aria2-wheel/commit/447f33e426ab952b252436d12c15cde44add8578)

# Checklist

- [x] I've read `CONTRIBUTING.md`.
- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
