### PR TITLE
build: fix unsupported platform tag `linux_*` for wheels

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,14 +24,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # keep `cross_host` consistent with `tag_4_build_enum` in `hatch_build.py`
-        cross_host:
-          - x86_64-linux-musl
-          - aarch64-linux-musl
-          - x86_64-w64-mingw32
-          - i686-w64-mingw32
+        # keep `whl_platform` consistent with `tag_4_build_enum` in `hatch_build.py`
+        whl_platform:
+          - manylinux_2_17_x86_64
+          - musllinux_1_1_x86_64
+          - manylinux_2_17_aarch64
+          - musllinux_1_1_aarch64
+          - win_amd64
+          - win32
     env:
-      CROSS_HOST: ${{ matrix.cross_host }}
+      WHL_PLATFORM: ${{ matrix.whl_platform }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/README.md
+++ b/README.md
@@ -33,10 +33,12 @@ So I build this python wheel to binding aria2 static build. You can install it b
 
 Now, we support:
 
-- [x] Windows 32bit
-- [x] Windows 64bit
-- [x] Linux x86_64
-- [x] Linux aarch64
+- [x] manylinux_2_17_x86_64
+- [x] musllinux_1_1_x86_64
+- [x] manylinux_2_17_aarch64
+- [x] musllinux_1_1_aarch64
+- [x] win_amd64
+- [x] win32
 
 ## Features
 
@@ -54,7 +56,7 @@ You can completely uninstall it by running `pip uninstall aria2`.
     - The bound aria2 executable file directly comes from `aria2-static-build` project, and `aria2-wheel` assumes no responsibility for your use.
     - The license of `aria2-wheel` project is consistent with `aria2-static-build` project.
 
-check `hatch_build.py` to know how we build the wheel.
+check `hatch_build.py` and `.github/workflows/publish.yml` to know how we build the wheel.
 
 ## Install
 


### PR DESCRIPTION
<!-- Thanks for contributing 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

### Pypi will reject `linux_*` platform tag.

So, this PR replace `linux_*` with `manylinux_2_17_*` and `musllinux_1_1_*`

Ref: https://github.com/deltachat/deltachat-core-rust/pull/4832

### The environment variable used to indicate cross-building wheels for different platforms has been changed

Previously, it was `CROSS_HOST`, and now it is `WHL_PLATFORM`.

For details, please refer to `hatch_build.py`


# Checklist

- [x] I've read `CONTRIBUTING.md`.
- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
